### PR TITLE
Allow classloader to be passed into EMS advanced properties

### DIFF
--- a/src/ems-impl/org/mc4j/ems/impl/jmx/connection/support/providers/JMXRemotingConnectionProvider.java
+++ b/src/ems-impl/org/mc4j/ems/impl/jmx/connection/support/providers/JMXRemotingConnectionProvider.java
@@ -76,7 +76,7 @@ public class JMXRemotingConnectionProvider extends AbstractConnectionProvider {
             // Create an RMI connector client
             JMXServiceURL url = new JMXServiceURL(this.connectionSettings.getServerUrl());
 
-            Hashtable env = new Hashtable();
+            Hashtable<String, Object> env = new Hashtable<String, Object>();
 
             if ((connectionSettings.getInitialContextName() != null) &&
                 (connectionSettings.getInitialContextName().trim().length() > 0)) {
@@ -120,8 +120,7 @@ public class JMXRemotingConnectionProvider extends AbstractConnectionProvider {
                 Set<Map.Entry<Object,Object>> entries = connectionSettings.getAdvancedProperties().entrySet();
                 for (Map.Entry entry : entries) {
                     String key = (String) entry.getKey();
-                    String value = (String) entry.getValue();
-
+                    Object value = entry.getValue();
                     env.put(key, value);
                 }
             }


### PR DESCRIPTION
Removes an unnecessary cast

Example:

ClassLoader ccl = Thread.currentThread().getContextClassLoader();
Properties p = new Properties();
p.put(JMXConnectorFactory.DEFAULT_CLASS_LOADER, ccl);

ConnectionSettings connectionSettings = new ConnectionSettings();
connectionSettings.setAdvancedProperties(p);
ConnectionFactory connectionFactory = new ConnectionFactory();
ConnectionProvider connectionProvider = connectionFactory.getConnectionProvider(connectionSettings);
